### PR TITLE
feat(gql): implement initial 'honeyBadgers' query

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,36 @@
 
 [![Build Status](https://travis-ci.org/Giners/honey-badger-insights.svg?branch=master)](https://travis-ci.org/Giners/honey-badger-insights)
 
+# Setup
+
+The app leverages several sources of data to provide the insights into honeypot intrusions. Some of the data sources require authentication/authorization to use. What follows are instructions for setting up your environment to make use of the data sources.
+
+## HoneyDB
+
+The app leverages a threat intelligence data feed from a source named HoneyDB. HoneyDB provides real-time data about honeypot activity. HoneyDB requires that authentication in order to use its data APIs. You can navigate [here](https://riskdiscovery.com/honeydb/#login) to login to HoneyDB with your GitHub account. After logging in to HoneyDB you will then be presented an API ID. Along with the API ID generate a key for accessing the threat information APIs of HoneyDB. You then need to make both the API ID and key available to the app so it can authenticate with HoneyDB. To do so you can set the environment variables named `HONEYDB_API_AUTH_ID` and `HONEYDB_API_AUTH_KEY`.
+
+```shell
+$ export HONEYDB_API_AUTH_ID=<Your HoneyDB API auth ID>
+$ export HONEYDB_API_AUTH_KEY=<Your HoneyDB API auth key>
+```
+
+Alternatively you can modify the config file at `src/server/config.js` to provide your API ID and auth key. Modify the file so it looks like the following:
+
+```javascript
+const config = {
+  // ... other config
+  // Service credentials
+  serviceCreds: {
+    honeyDB: {
+      id: process.env.HONEYDB_API_AUTH_ID || 'Your HoneyDB API auth ID',
+      key: process.env.HONEYDB_API_AUTH_KEY || 'Your HoneyDB API auth key',
+    },
+  },
+}
+
+export default config
+```
+
 # License
 
 [MIT](https://gine.mit-license.org/)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "precommit": "lint-staged && yarn test",
     "test": "run-s test:mocha test:eslint",
     "test:mocha":
-      "mocha --exit --require test/utils/setup-babel-register --recursive test/unit",
+      "mocha --exit --require test/utils/setup-babel-register --require @babel/polyfill --recursive test/unit",
     "test:eslint":
       "eslint --max-warnings 0 --cache --ext .js,.jsx,.spec.js,.spec.jsx src/* test/*",
     "build:svr": "babel src/server -d lib/server",
@@ -35,7 +35,9 @@
     "*.{js,jsx,json,css,md}": ["prettier --write", "git add"]
   },
   "dependencies": {
-    "express": "^4.16.3"
+    "express": "^4.16.3",
+    "graphql": "^0.13.2",
+    "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.46",

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -3,6 +3,13 @@ const config = {
   app: {
     port: process.env.port || 3000,
   },
+  // Service credentials
+  serviceCreds: {
+    honeyDB: {
+      id: process.env.HONEYDB_API_AUTH_ID || 'No API auth ID found!',
+      key: process.env.HONEYDB_API_AUTH_KEY || 'No API auth key found!',
+    },
+  },
 }
 
 export default config

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -1,3 +1,9 @@
+/**
+ * Config object that contains information/details to allow the app to function properly.
+ * Information/details are gathered from environment variables. If the appropriate environment
+ * variable isn't set then a default value is used. Note that some default values will cause the app
+ * to no function properly, such as defaults for credentials for services that are used.
+ */
 const config = {
   // Config for the app/server
   app: {

--- a/src/server/graphql/schema.js
+++ b/src/server/graphql/schema.js
@@ -20,7 +20,7 @@ const honeyDBAPIAuthIDHeader = 'X-HoneyDb-ApiId'
 const honeyDBAPIAuthKeyHeader = 'X-HoneyDb-ApiKey'
 
 /** Used to limit how much data (honey badgers) we ultimately return */
-export const maxHoneyDBDatums = 100
+const maxHoneyDBDatums = 100
 
 /**
  * The entry point into our graph of relationships between types we define. You can read this as:

--- a/src/server/graphql/schema.js
+++ b/src/server/graphql/schema.js
@@ -1,0 +1,82 @@
+import 'isomorphic-fetch'
+
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+} from 'graphql'
+
+import HoneyBadgerType from './types'
+import config from './../config'
+
+/** The URL for the HoneyDB API that returns a list of bad hosts from the last 24 hours */
+const honeyDBBadHostsAPIURL = 'https://riskdiscovery.com/honeydb/api/bad-hosts'
+
+/** HoneyDB auth header for accessing its APIs that identifies who is accessing the API */
+const honeyDBAPIAuthIDHeader = 'X-HoneyDb-ApiId'
+
+/** HoneyDB auth header for accessing its APIs that verifies who is accessing the API */
+const honeyDBAPIAuthKeyHeader = 'X-HoneyDb-ApiKey'
+
+/** Used to limit how much data (honey badgers) we ultimately return */
+export const maxHoneyDBDatums = 100
+
+/**
+ * The entry point into our graph of relationships between types we define. You can read this as:
+ * "You can ask me, the root query, about honey badgers in the application." The most important part
+ * of the query is the 'resolve()' functions on the fields which is used to actually return data on
+ * the defined types.
+ */
+const rootQueryType = new GraphQLObjectType({
+  name: 'RootQuery',
+  fields: {
+    honeyBadgers: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(HoneyBadgerType)),
+      ),
+      resolve() {
+        const { id, key } = config.serviceCreds.honeyDB
+
+        return fetch(honeyDBBadHostsAPIURL, {
+          headers: {
+            [honeyDBAPIAuthIDHeader]: id,
+            [honeyDBAPIAuthKeyHeader]: key,
+          },
+        })
+          .then(res => res.json())
+          .then(honeyDBData => {
+            let honeyBadgers = honeyDBData
+
+            // Control how much data we return to our consumers. We are presuming (which is bad - but
+            // for the sake of simplicity) that the data returned to us from HoneyDB is in sorted
+            // order with the most frequently seen bad host/IP indexed at the beginning of the array.
+            // As a result of this assumption we will end up returning the top honey badgers to our
+            // consumers.
+            if (honeyBadgers.length > maxHoneyDBDatums) {
+              honeyBadgers = honeyBadgers.slice(0, maxHoneyDBDatums)
+            }
+
+            // Map the data returned by HoneyDB to return an object defined by our GraphQL schema.
+            // Disable the ESLint error 'camelcase' as HoneyDB returns the data with underscores in
+            // the datas identifiers
+            // eslint-disable-next-line camelcase
+            honeyBadgers = honeyBadgers.map(({ remote_host }) => ({
+              ipAddress: remote_host,
+            }))
+
+            return honeyBadgers
+          })
+      },
+      description: `Gets the top ${maxHoneyDBDatums} honey badgers from the last 24 hours based on how many times they have been seen`,
+    },
+  },
+  description: 'The GraphQL queries available in the app',
+})
+
+/** The instance of our GraphQL schema that can be used in our app */
+const schema = new GraphQLSchema({
+  query: rootQueryType,
+})
+
+export default schema

--- a/src/server/graphql/types.js
+++ b/src/server/graphql/types.js
@@ -1,0 +1,15 @@
+import { GraphQLNonNull, GraphQLObjectType, GraphQLString } from 'graphql'
+
+const HoneyBadgerType = new GraphQLObjectType({
+  name: 'HoneyBadger',
+  fields: {
+    ipAddress: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The IP address of the entity caught in a honeypot',
+    },
+  },
+  description:
+    'A honey badger is someone or something that was caught in a honeypot',
+})
+
+export default HoneyBadgerType

--- a/test/unit/server/graphql/schemaQueries.spec.js
+++ b/test/unit/server/graphql/schemaQueries.spec.js
@@ -1,0 +1,112 @@
+// ESLint config
+//
+// Although ESLint prefers arrow functions we disable any warnings/errors for not using them as
+// Mocha discourages its use as we the Mocha context can't be accessed.For more info see:
+// https://mochajs.org/#arrow-functions
+/* eslint func-names: 0, prefer-arrow-callback: 0 */
+//
+// The use of Chai/expect assertions causes ESLint to believe we have a bunch of unused
+// expressions (we do I guess). We disable the check for them and use an ESLint check that ignores
+// any unused expressions from the use of Chai/expect assertions.
+/* eslint no-unused-expressions: 0, chai-friendly/no-unused-expressions: 2 */
+//
+// We disable the errors about the rule about underscore dangles as the GraphQL response when we
+// query for the schema/query types contains data members with underscores as part of their
+// identifiers.
+/* eslint no-underscore-dangle: 0 */
+
+// General 3rd-party supporting test libs
+import { expect } from 'chai'
+
+// General 3rd-party supporting libs
+import { graphql } from 'graphql'
+import 'isomorphic-fetch'
+
+// Our GraphQL schema that is under test
+import schema from './../../../../src/server/graphql/schema'
+
+describe('Schema query tests:', function() {
+  // How many queries we expect in our schema. This is used to simply ensure that we update these
+  // tests after adding/removing a query from our schema.
+  const expectedSchemaQueries = 1
+
+  // This test is simply to help us remembr to test all of our queries. It will fail once you
+  // have added a new field to the root query. After adding a test for the root query please
+  // update this test to reflect that you have tested all of the queries.
+  it('We have tested all of our queries:', async function() {
+    const query = `
+      {
+        __schema {
+          queryType {
+            name
+            fields {
+              name
+            }
+          }
+        }
+      }
+    `
+
+    const result = await graphql(schema, query)
+
+    expect(result).to.exist
+    expect(result.errors).to.be.undefined
+    expect(result.data).to.exist
+
+    const { __schema } = result.data
+
+    expect(__schema).to.exist
+    expect(__schema.queryType).to.exist
+    expect(__schema.queryType.name).to.equal('RootQuery')
+
+    // Update how the expected length count of our root query after you have added tests for the
+    // new queries you have added
+    expect(__schema.queryType.fields).to.exist
+    expect(
+      __schema.queryType.fields.length,
+      'Found additional query fields - Update after writing tests for the queries you added',
+    ).to.equal(expectedSchemaQueries)
+  })
+
+  describe('Query: honeyBadgers', function() {
+    const query = `
+      {
+        honeyBadgers {
+          ipAddress
+        }
+      }
+    `
+
+    // Helper method to perform common basic validation on the 'honeyBadgers' query. Ought to be
+    // invoked before more specific validation is done on the 'honeyBadgers' query.
+    const validateHoneyBadgersQuery = result => {
+      expect(
+        result.errors,
+        `Didn't expect any errors but got: ${result.errors}`,
+      ).to.be.undefined
+      expect(result.data).to.exist
+      expect(result.data.honeyBadgers).to.exist
+    }
+
+    it('Query returns honey badgers', async function() {
+      // Increase the timeout in our unit test as our schema makes async calls to HoneyDB
+      this.timeout(5000)
+
+      const result = await graphql(schema, query)
+
+      validateHoneyBadgersQuery(result)
+    })
+
+    it('Query returns at most 100 honey badgers', async function() {
+      // Increase the timeout in our unit test as our schema makes async calls to HoneyDB
+      this.timeout(5000)
+
+      const result = await graphql(schema, query)
+
+      validateHoneyBadgersQuery(result)
+
+      // At most the 'honeyBadgers' query will return 100 entries
+      expect(result.data.honeyBadgers.length).to.be.at.most(100)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,6 +2753,12 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphql@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
+  dependencies:
+    iterall "^1.2.1"
+
 growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
@@ -3308,7 +3314,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
@@ -3318,6 +3324,10 @@ isomorphic-fetch@^2.1.1:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+iterall@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
 
 jest-config@^22.4.3:
   version "22.4.3"


### PR DESCRIPTION
This PR seeks to merge in the initial implementation of our GraphQL schema as well as our first query named `honeyBadgers`. The `honeyBadgers` query allows a schema/client consumer to get the most invasive intruders into honeypots in the last 24 hours. It generates this data by relying on a threat intelligence data feed from HoneyDB.

Instructions on how to setup the app for use with HoneyDB are also included.

Note that this doesn't seek to merge in a GraphQL API endpoint. No work was done for that. Rather that work will be done in another issue/PR.