### PR TITLE
feat(gql): add 'geoLocations' query to GQL schema to get locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "start:dev:cli":
       "webpack-dev-server --mode development --debug --progress --host 0.0.0.0",
     "start:dev:svr": "babel-node src/server/server",
+    "watch:dev:svr": "nodemon -w src/server --exec \"yarn start:dev:svr\"",
     "doc": "esdoc",
     "start:doc": "http-server ./docs -c-1"
   },
@@ -96,6 +97,7 @@
     "jsdom": "^11.9.0",
     "lint-staged": "^7.0.4",
     "mocha": "^5.1.1",
+    "nodemon": "^1.17.3",
     "prettier": "^1.12.1",
     "webpack": "^4.6.0",
     "webpack-cli": "^2.0.15",

--- a/src/client/components/HoneyBadgersTable.jsx
+++ b/src/client/components/HoneyBadgersTable.jsx
@@ -21,12 +21,24 @@ const getHoneyBadgersRows = honeyBadgers =>
     // Supply the minimum amount of info we expect in a row which is the IP address and the amount
     // of times we have seen the entity in the last 24 hours. Add a 'Loading' flag as the default
     // for all of the other info that may not be loaded yet.
-    const { ipAddress, count } = honeyBadger
-    const row = { ipAddress, count, asn: 'Loading' }
+    const { ipAddress, count, geoLocation, as } = honeyBadger
 
-    // Add the autonomous system number if autonomous system info has been loaded...
-    if (honeyBadger.as) {
-      row.asn = honeyBadger.as.asn
+    const row = {
+      ipAddress,
+      count,
+      country: 'Loading',
+      asn: 'Loading',
+    }
+
+    // Add the additional info if it has been loaded:
+    // * Autonomous system number if autonomous system info has been loaded
+    // * Country of origin if geospatial location info has been loaded
+    if (geoLocation) {
+      row.country = geoLocation.country
+    }
+
+    if (as) {
+      row.asn = as.asn
     }
 
     return row
@@ -38,6 +50,7 @@ const HoneyBadgersTable = ({ honeyBadgers }) => (
     columns={[
       { name: 'ipAddress', title: 'IP Address' },
       { name: 'count', title: 'Times Seen Last 24 Hours' },
+      { name: 'country', title: 'Country of Origin' },
       { name: 'asn', title: 'Autonomous System #' },
     ]}
   >

--- a/src/client/graphql/queries.js
+++ b/src/client/graphql/queries.js
@@ -19,3 +19,15 @@ export const autonomousSystemsQuery = gql`
     }
   }
 `
+
+export const geoLocationsQuery = gql`
+  query GeoLocations($ipAddresses: [String!]!) {
+    geoLocations(ipAddresses: $ipAddresses) {
+      ipAddress
+      latitude
+      longitude
+      country
+      continent
+    }
+  }
+`

--- a/src/server/graphql/data/geoLocationsData
+++ b/src/server/graphql/data/geoLocationsData
@@ -1,0 +1,177 @@
+[
+  {
+    "ipAddress": "95.216.147.231",
+    "latitude": 60.1708,
+    "longitude": 24.9375,
+    "country": "Finland",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "46.29.248.90",
+    "latitude": 59.3247,
+    "longitude": 18.056,
+    "country": "Sweden",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "104.17.40.113",
+    "latitude": 37.751,
+    "longitude": -97.822,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "81.218.45.146",
+    "latitude": 31.5,
+    "longitude": 34.75,
+    "country": "Israel",
+    "continent": "Asia"
+  },
+  {
+    "ipAddress": "90.231.42.220",
+    "latitude": 59.3833,
+    "longitude": 17.9167,
+    "country": "Sweden",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "147.135.169.235",
+    "latitude": 48.8582,
+    "longitude": 2.3387000000000002,
+    "country": "France",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "104.17.39.113",
+    "latitude": 37.751,
+    "longitude": -97.822,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "98.212.111.60",
+    "latitude": 40.1291,
+    "longitude": -89.3641,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "66.70.173.21",
+    "latitude": 45.504,
+    "longitude": -73.5747,
+    "country": "Canada",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "142.196.229.24",
+    "latitude": 28.6766,
+    "longitude": -81.1991,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "104.17.41.113",
+    "latitude": 37.751,
+    "longitude": -97.822,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "91.236.239.102",
+    "latitude": 48.8582,
+    "longitude": 2.3387000000000002,
+    "country": "France",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "75.176.121.42",
+    "latitude": 33.9792,
+    "longitude": -81.2589,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "104.17.37.113",
+    "latitude": 37.751,
+    "longitude": -97.822,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "174.60.100.187",
+    "latitude": 41.3988,
+    "longitude": -76.7922,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "5.62.63.221",
+    "latitude": 37.751,
+    "longitude": -97.822,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "212.129.56.125",
+    "latitude": 48.8582,
+    "longitude": 2.3387000000000002,
+    "country": "France",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "75.176.109.242",
+    "latitude": 33.9792,
+    "longitude": -81.2589,
+    "country": "United States",
+    "continent": "North America"
+  },
+  {
+    "ipAddress": "147.135.169.234",
+    "latitude": 48.8582,
+    "longitude": 2.3387000000000002,
+    "country": "France",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "136.243.74.134",
+    "latitude": 51.2993,
+    "longitude": 9.491,
+    "country": "Germany",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "54.37.104.81",
+    "latitude": 48.8582,
+    "longitude": 2.3387000000000002,
+    "country": "France",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "195.140.215.9",
+    "latitude": 51.3981,
+    "longitude": -0.4479,
+    "country": "United Kingdom",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "182.100.67.129",
+    "latitude": 28.55,
+    "longitude": 115.9333,
+    "country": "China",
+    "continent": "Asia"
+  },
+  {
+    "ipAddress": "95.68.221.51",
+    "latitude": 54.3333,
+    "longitude": 48.4,
+    "country": "Russia",
+    "continent": "Europe"
+  },
+  {
+    "ipAddress": "104.17.38.113",
+    "latitude": 37.751,
+    "longitude": -97.822,
+    "country": "United States",
+    "continent": "North America"
+  }
+]

--- a/src/server/graphql/schema.js
+++ b/src/server/graphql/schema.js
@@ -1,3 +1,9 @@
+// ESLint config
+// We disable the ESLing rule 'camelcase' as the data returned to us by the 3rd party services we
+// use is snake cased. We ourselves shouldn't look to use snake case but continue to use camelcased
+// identifiers.
+/* eslint-disable camelcase */
+
 import { promisify } from 'util'
 import { readFile } from 'fs'
 import { resolve } from 'path'
@@ -12,7 +18,8 @@ import {
   GraphQLSchema,
 } from 'graphql'
 
-import { ASType, TopHoneyBadgerType } from './types'
+import { ASType, GeoLocationType, TopHoneyBadgerType } from './types'
+
 import config from './../config'
 
 /**
@@ -24,6 +31,16 @@ import config from './../config'
  * set of IPs as a list that is comma separated.
  */
 const apilityASBatchAPIURL = 'https://api.apility.net/as_batch/ip'
+
+/**
+ * The URL for the Apility API that returns geospatial info for a set of IPs. The API expects the
+ * set of IPs as a list of comma separated IPs used as the last URI segment of this URL (i.e. you
+ * need to add them).
+ *
+ * Note that the URL doesn't contain an ending '/' character. You need to add it before adding the
+ * set of IPs as a list that is comma separated.
+ */
+const apilityGeoIPBatchAPIURL = 'https://api.apility.net/geoip_batch'
 
 /**
  * Apility auth header for accessing its APIs that identifies who is accessing the API based on a
@@ -44,6 +61,20 @@ const apilityAPIAuthTokenHeader = 'X-Auth-Token'
  */
 const getApilityASBatchAPIURL = ipAddresses =>
   `${apilityASBatchAPIURL}/${ipAddresses.join(',')}`
+
+/**
+ * Helper method to construct the URL used to query for the geospatial info associated with a set of
+ * IPs from Apility.
+ *
+ * @param {string[]} ipAddresses - Array of IP addresses to query for the geospatial info associated
+ * with them. No checking/validation is done of this parameter so if anything but an array of
+ * strings is passed will cause this function to break.
+ *
+ * @returns {string} - Formed URL that can be used to query for the geospatial info associated with
+ * a set of IPs from Apility
+ */
+const getApilityGeoIPBatchAPIURL = ipAddresses =>
+  `${apilityGeoIPBatchAPIURL}/${ipAddresses.join(',')}`
 
 /** The URL for the HoneyDB API that returns a list of bad hosts from the last 24 hours */
 const honeyDBBadHostsAPIURL = 'https://riskdiscovery.com/honeydb/api/bad-hosts'
@@ -88,7 +119,7 @@ const rootQueryType = new GraphQLObjectType({
           ).then(data => JSON.parse(data))
         }
 
-        // If we aren't returning returning mock data from disk then query the HoneyDB service
+        // If we aren't returning mock data from disk then query the HoneyDB service
         const { id, key } = config.serviceCreds.honeyDB
 
         return fetch(honeyDBBadHostsAPIURL, {
@@ -110,10 +141,7 @@ const rootQueryType = new GraphQLObjectType({
               honeyBadgers = honeyBadgers.slice(0, maxHoneyDBDatums)
             }
 
-            // Map the data returned by HoneyDB to return an object defined by our GraphQL schema.
-            // Disable the ESLint error 'camelcase' as HoneyDB returns the data with underscores in
-            // the datas identifiers
-            // eslint-disable-next-line camelcase
+            // Map the data returned by HoneyDB to return a type defined by our GraphQL schema.
             honeyBadgers = honeyBadgers.map(({ remote_host, count }) => ({
               ipAddress: remote_host,
               count,
@@ -143,7 +171,7 @@ const rootQueryType = new GraphQLObjectType({
           ).then(data => JSON.parse(data))
         }
 
-        // If we aren't returning returning mock data from disk then query the Apility service
+        // If we aren't returning mock data from disk then query the Apility service
         const { token } = config.serviceCreds.apility
         const url = getApilityASBatchAPIURL(ipAddresses)
 
@@ -174,6 +202,60 @@ const rootQueryType = new GraphQLObjectType({
       },
       description:
         'Gets the autonomous systems associated with the IP addresses of honey badgers',
+    },
+    geoLocations: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GeoLocationType)),
+      ),
+      args: {
+        ipAddresses: {
+          type: new GraphQLNonNull(
+            new GraphQLList(new GraphQLNonNull(GraphQLString)),
+          ),
+          description:
+            'A list of honey badger IPs used to look up their associated geospatial locations',
+        },
+      },
+      resolve(parentNode, { ipAddresses }) {
+        // Return mock data from disk if signalled to do so
+        if (returnMockData) {
+          return promisify(readFile)(
+            resolve(__dirname, './data/geoLocationsData'),
+          ).then(data => JSON.parse(data))
+        }
+
+        // If we aren't returning mock data from disk then query the Apility service
+        const { token } = config.serviceCreds.apility
+        const url = getApilityGeoIPBatchAPIURL(ipAddresses)
+
+        return fetch(url, {
+          headers: {
+            [apilityAPIAuthTokenHeader]: token,
+          },
+        })
+          .then(res => res.json())
+          .then(json =>
+            json.response.map(entry => {
+              // Iterate over the entries in the response from Apility in regards to getting
+              // geospatial location details and form it into the data representation that is
+              // defined by the GraphQL type that we return
+              const {
+                ip,
+                geoip: { latitude, longitude, country_names, continent_names },
+              } = entry
+
+              return {
+                ipAddress: ip,
+                latitude,
+                longitude,
+                country: country_names.en,
+                continent: continent_names.en,
+              }
+            }),
+          )
+      },
+      description:
+        'Gets the geospatial locations associated with the IP addresses of honey badgers',
     },
   },
   description: 'The GraphQL queries available in the app',

--- a/src/server/graphql/types.js
+++ b/src/server/graphql/types.js
@@ -1,9 +1,40 @@
 import {
+  GraphQLFloat,
   GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql'
+
+export const GeoLocationType = new GraphQLObjectType({
+  name: 'GeoLocation',
+  fields: {
+    ipAddress: {
+      type: new GraphQLNonNull(GraphQLString),
+      description:
+        'The IP address of a honey badger that the geospatial location is associated with',
+    },
+    latitude: {
+      type: new GraphQLNonNull(GraphQLFloat),
+      description:
+        'The latitude of the location of the honey badger (e.g. 47.6062)',
+    },
+    longitude: {
+      type: new GraphQLNonNull(GraphQLFloat),
+      description:
+        'The longitude of the location of the honey badger (e.g. 122.3321)',
+    },
+    country: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The country that the honey badger resides in',
+    },
+    continent: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The continent the honey badger resides in',
+    },
+  },
+  description: 'The geospatial location of a honey badger',
+})
 
 export const ASType = new GraphQLObjectType({
   name: 'AS',

--- a/test/int/client/containers/App.spec.jsx
+++ b/test/int/client/containers/App.spec.jsx
@@ -108,30 +108,59 @@ describe('React component test: <App>', function() {
     it('Promise resolves to map with autonomous systems info injected', async function() {
       // First query for honey badgers so we can pass them to the
       // 'App.collectAutnomousSystemsInfo()' method...
-      const honeyBadgers = await App.collectTopHoneyBadgersInfo()
+      let honeyBadgers = await App.collectTopHoneyBadgersInfo()
 
       // Now query for autonomous systems info and check that the map of honey badgers has been
       // updated inline with the invocation of the 'App.collectAutonomousSystemsInfo()' method...
-      const promise = App.collectAutonomousSystemsInfo(honeyBadgers)
+      await App.collectAutonomousSystemsInfo(honeyBadgers)
 
-      // So weird... I would have liked to await the call to 'App.collectAutonomousSystemsInfo' but
-      // was getting errors like 'TypeError: _App.default.collectAutonomousSystemsInfo(...)'. This
-      // confused me since we are able to do this with 'App.collectTopHoneyBadgersInfo()'. I tried
-      // to resolve it with some Babel plugins (plugin-transform-async-to-generator and
-      // plugin-transform-runtime) but they didn't work. In the future if there is more time we
-      // ought to revisit this problem and solve it so we can learn from it.
-      return promise.then(() => {
-        // Check that we correctly populated our entries on our map...
-        ;[...honeyBadgers.values()].forEach(value => {
-          expect(value).to.be.an('object')
-          expect(value.as).to.be.an('object')
-          expect(value.as.name).to.be.a('string')
-          expect(value.as.name).to.not.be.empty
-          expect(value.as.asn).to.be.a('number')
-          expect(value.as.asn).to.be.above(0)
-          expect(value.as.countryCode).to.be.a('string')
-          expect(value.as.countryCode).to.not.be.empty
-        })
+      // Check that we correctly populated our entries on our map...
+      honeyBadgers = [...honeyBadgers.values()]
+      honeyBadgers.forEach(honeyBadger => {
+        expect(honeyBadger).to.be.an('object')
+        expect(honeyBadger.as).to.be.an('object')
+
+        const { name, asn, countryCode } = honeyBadger.as
+
+        expect(name).to.be.a('string')
+        expect(name).to.not.be.empty
+        expect(asn).to.be.a('number')
+        expect(asn).to.be.above(0)
+        expect(countryCode).to.be.a('string')
+        expect(countryCode).to.not.be.empty
+      })
+    })
+  })
+
+  describe('collectGeoLocationsInfo():', function() {
+    it('Promise resolves to map with geospatial locations info injected', async function() {
+      // First query for honey badgers so we can pass them to the
+      // 'App.collectGeoLocationsInfo()' method...
+      let honeyBadgers = await App.collectTopHoneyBadgersInfo()
+
+      // Now query for geospatial locations info and check that the map of honey badgers has been
+      // updated inline with the invocation of the 'App.collectGeoLocationsInfo()' method...
+      await App.collectGeoLocationsInfo(honeyBadgers)
+
+      // Check that we correctly populated our entries on our map...
+      honeyBadgers = [...honeyBadgers.values()]
+      honeyBadgers.forEach(honeyBadger => {
+        expect(honeyBadger).to.be.an('object')
+        expect(honeyBadger.geoLocation).to.be.an('object')
+
+        const {
+          latitude,
+          longitude,
+          country,
+          continent,
+        } = honeyBadger.geoLocation
+
+        expect(latitude).to.be.a('number')
+        expect(longitude).to.be.a('number')
+        expect(country).to.be.a('string')
+        expect(country).to.not.be.empty
+        expect(continent).to.be.a('string')
+        expect(continent).to.not.be.empty
       })
     })
   })

--- a/test/unit/client/components/HoneyBadgersTable.spec.jsx
+++ b/test/unit/client/components/HoneyBadgersTable.spec.jsx
@@ -66,7 +66,7 @@ describe('React component test: <HoneyBadgersTable>', function() {
 
     it('Rows rendered (honey badgers data w/o additional data)', function() {
       // Create data as if we have only issued our initial GraphQL query of 'topHoneyBadgers'
-      const honeyBadgers = [{ ipAddress: '1.1.1.1', count: '987' }]
+      const honeyBadgers = [{ ipAddress: '1.1.1.1', count: 987 }]
 
       hbtWrapper.setProps({ honeyBadgers })
 
@@ -75,18 +75,23 @@ describe('React component test: <HoneyBadgersTable>', function() {
       const rows = hbtWrapper.find(Grid).prop('rows')
       expect(rows.length).to.equal(honeyBadgers.length)
 
-      rows.forEach(row => {
-        // This assertion is meant to remind us to update the following assertions. It will fail as
-        // we add additional keys to the row data and don't update the tests. We currently expect
-        // the following keys: 'ipAddress', 'count', 'asn'
-        expect(Object.keys(row).length).to.equal(3)
-        expect(row.ipAddress).to.not.be.empty
-        expect(parseInt(row.count, 10)).to.be.above(0)
+      // Verify that we correctly set the data in a row given a honey badger
+      const honeyBadger = honeyBadgers[0]
+      const row = rows[0]
 
-        // This test presumes we haven't yet queried for autonomous systems data so we expect it any
-        // info we would display about autonomous systems to say 'Loading' at this point
-        expect(row.asn).to.equal('Loading')
-      })
+      // This assertion is meant to remind us to update the following assertions. It will fail as
+      // we add additional keys to the row data and don't update the tests. We currently expect
+      // the following keys: 'ipAddress', 'count', 'country', 'asn'
+      expect(Object.keys(row).length).to.equal(4)
+
+      // Now check for the data we expect...
+      expect(row.ipAddress).to.equal(honeyBadger.ipAddress)
+      expect(parseInt(row.count, 10)).to.equal(honeyBadger.count)
+
+      // This test presumes we haven't yet queried for other data yet so we expect any info we
+      // from other data we would display to say 'Loading' at this point
+      expect(row.country).to.equal('Loading')
+      expect(row.asn).to.equal('Loading')
 
       expect(toJson(hbtWrapper)).to.matchSnapshot()
     })
@@ -97,7 +102,7 @@ describe('React component test: <HoneyBadgersTable>', function() {
       const honeyBadgers = [
         {
           ipAddress: '1.1.1.1',
-          count: '987',
+          count: 987,
           as: {
             name: 'OVH SAS',
             asn: 16276,
@@ -113,15 +118,69 @@ describe('React component test: <HoneyBadgersTable>', function() {
       const rows = hbtWrapper.find(Grid).prop('rows')
       expect(rows.length).to.equal(honeyBadgers.length)
 
-      rows.forEach(row => {
-        // This assertion is meant to remind us to update the following assertions. It will fail as
-        // we add additional keys to the row data and don't update the tests. We currently expect
-        // the following keys: 'ipAddress', 'count', 'asn'
-        expect(Object.keys(row).length).to.equal(3)
-        expect(row.ipAddress).to.not.be.empty
-        expect(parseInt(row.count, 10)).to.be.above(0)
-        expect(parseInt(row.asn, 10)).to.be.above(0)
-      })
+      // Verify that we correctly set the data in a row given a honey badger
+      const honeyBadger = honeyBadgers[0]
+      const row = rows[0]
+
+      // This assertion is meant to remind us to update the following assertions. It will fail as
+      // we add additional keys to the row data and don't update the tests. We currently expect
+      // the following keys: 'ipAddress', 'count', 'country, 'asn'
+      expect(Object.keys(row).length).to.equal(4)
+
+      // Now check for the data we expect...
+      expect(row.ipAddress).to.equal(honeyBadger.ipAddress)
+      expect(parseInt(row.count, 10)).to.equal(honeyBadger.count)
+      expect(parseInt(row.asn, 10)).to.equal(honeyBadger.as.asn)
+
+      // This test presumes we haven't yet queried for geospatial locations data so we expect any
+      // info we would display about that data to say 'Loading' at this point
+      expect(row.country).to.equal('Loading')
+
+      expect(toJson(hbtWrapper)).to.matchSnapshot()
+    })
+
+    it('Rows rendered (honey badgers data w/ AS and location data)', function() {
+      // Create data as if we have issued the 'topHoneyBadgers', 'autonomousSystems', and
+      // 'geoLocations' queries to our GraphQL service/API endpoint
+      const honeyBadgers = [
+        {
+          ipAddress: '1.1.1.1',
+          count: 987,
+          geoLocation: {
+            latitude: 47.6062,
+            longitude: 122.3321,
+            country: 'United State',
+            continent: 'North America',
+          },
+          as: {
+            name: 'OVH SAS',
+            asn: 16276,
+            countryCode: 'FR',
+          },
+        },
+      ]
+
+      hbtWrapper.setProps({ honeyBadgers })
+
+      // We should have some rows since we have some honey badgers. Check and ensure that each row
+      // specifies it is loading data where appropriate
+      const rows = hbtWrapper.find(Grid).prop('rows')
+      expect(rows.length).to.equal(honeyBadgers.length)
+
+      // Verify that we correctly set the data in a row given a honey badger
+      const honeyBadger = honeyBadgers[0]
+      const row = rows[0]
+
+      // This assertion is meant to remind us to update the following assertions. It will fail as
+      // we add additional keys to the row data and don't update the tests. We currently expect
+      // the following keys: 'ipAddress', 'count', 'country', 'asn'
+      expect(Object.keys(row).length).to.equal(4)
+
+      // Now check the data we expect...
+      expect(row.ipAddress).to.equal(honeyBadger.ipAddress)
+      expect(parseInt(row.count, 10)).to.equal(honeyBadger.count)
+      expect(parseInt(row.asn, 10)).to.equal(honeyBadger.as.asn)
+      expect(row.country).to.equal(honeyBadger.geoLocation.country)
 
       expect(toJson(hbtWrapper)).to.matchSnapshot()
     })

--- a/test/unit/client/components/HoneyBadgersTable.spec.jsx.snap
+++ b/test/unit/client/components/HoneyBadgersTable.spec.jsx.snap
@@ -13,12 +13,67 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
         "title": "Times Seen Last 24 Hours",
       },
       Object {
+        "name": "country",
+        "title": "Country of Origin",
+      },
+      Object {
         "name": "asn",
         "title": "Autonomous System #",
       },
     ]
   }
   rows={Array []}
+>
+  <PagingState
+    defaultCurrentPage={0}
+    defaultPageSize={10}
+    pageSize={5}
+  />
+  <IntegratedPaging />
+  <Table$$1
+    messages={Object {}}
+  />
+  <TableHeaderRow$$1
+    messages={Object {}}
+  />
+  <PagingPanel$$1
+    messages={Object {}}
+  />
+</Grid$$1>
+`;
+
+exports[`React component test: <HoneyBadgersTable> Renders correctly for given application state: Rows rendered (honey badgers data w/ AS and location data) 1`] = `
+<Grid$$1
+  columns={
+    Array [
+      Object {
+        "name": "ipAddress",
+        "title": "IP Address",
+      },
+      Object {
+        "name": "count",
+        "title": "Times Seen Last 24 Hours",
+      },
+      Object {
+        "name": "country",
+        "title": "Country of Origin",
+      },
+      Object {
+        "name": "asn",
+        "title": "Autonomous System #",
+      },
+    ]
+  }
+  rows={
+    Array [
+      Object {
+        "asn": 16276,
+        "count": 987,
+        "country": "United State",
+        "ipAddress": "1.1.1.1",
+      },
+    ]
+  }
 >
   <PagingState
     defaultCurrentPage={0}
@@ -51,6 +106,10 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
         "title": "Times Seen Last 24 Hours",
       },
       Object {
+        "name": "country",
+        "title": "Country of Origin",
+      },
+      Object {
         "name": "asn",
         "title": "Autonomous System #",
       },
@@ -60,7 +119,8 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
     Array [
       Object {
         "asn": 16276,
-        "count": "987",
+        "count": 987,
+        "country": "Loading",
         "ipAddress": "1.1.1.1",
       },
     ]
@@ -97,6 +157,10 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
         "title": "Times Seen Last 24 Hours",
       },
       Object {
+        "name": "country",
+        "title": "Country of Origin",
+      },
+      Object {
         "name": "asn",
         "title": "Autonomous System #",
       },
@@ -106,7 +170,8 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
     Array [
       Object {
         "asn": "Loading",
-        "count": "987",
+        "count": 987,
+        "country": "Loading",
         "ipAddress": "1.1.1.1",
       },
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,6 +1226,12 @@ ajv@^6.1.0:
     json-schema-traverse "^0.3.0"
     uri-js "^3.0.2"
 
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  dependencies:
+    string-width "^2.0.0"
+
 ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -2273,6 +2279,18 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
+boxen@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2493,13 +2511,17 @@ camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
-camelcase@^4.1.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-lite@^1.0.30000830:
   version "1.0.30000830"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000830.tgz#cb96b8a2dd3cbfe04acea2af3c4e894249095328"
+
+capture-stack-trace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2693,6 +2715,10 @@ classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
+
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -2877,6 +2903,17 @@ concat-stream@^1.5.0, concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+configstore@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
+  dependencies:
+    dot-prop "^4.1.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^2.0.0"
+    xdg-basedir "^3.0.0"
+
 connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
@@ -2992,6 +3029,12 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  dependencies:
+    capture-stack-trace "^1.0.0"
+
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -3059,6 +3102,10 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
 css-select@~1.2.0:
   version "1.2.0"
@@ -3193,6 +3240,10 @@ deep-equal@^1.0.1:
 deep-extend@^0.4.0, deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
+deep-extend@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3412,6 +3463,12 @@ domutils@^1.5.1:
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
+  dependencies:
+    is-obj "^1.0.0"
+
+dot-prop@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:
     is-obj "^1.0.0"
 
@@ -4527,6 +4584,22 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
+
 got@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"
@@ -4895,6 +4968,10 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+
 ignore-walk@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
@@ -4904,6 +4981,10 @@ ignore-walk@^3.0.1:
 ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
+
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
 import-local@^1.0.0:
   version "1.0.0"
@@ -5204,6 +5285,17 @@ is-in-browser@^1.0.2, is-in-browser@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
+is-installed-globally@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
+  dependencies:
+    global-dirs "^0.1.0"
+    is-path-inside "^1.0.0"
+
+is-npm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+
 is-number-object@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
@@ -5281,6 +5373,10 @@ is-primitive@^2.0.0:
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
 
 is-regex@^1.0.4:
   version "1.0.4"
@@ -5851,6 +5947,12 @@ klaw@^1.0.0:
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
   optionalDependencies:
     graceful-fs "^4.1.9"
+
+latest-version@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
+  dependencies:
+    package-json "^4.0.0"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -6656,6 +6758,21 @@ node-pre-gyp@^0.9.0:
     semver "^5.3.0"
     tar "^4"
 
+nodemon@^1.17.3:
+  version "1.17.3"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.17.3.tgz#3b0bbc2ee05ccb43b1aef15ba05c63c7bc9b8530"
+  dependencies:
+    chokidar "^2.0.2"
+    debug "^3.1.0"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.0.4"
+    pstree.remy "^1.1.0"
+    semver "^5.5.0"
+    supports-color "^5.2.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.2"
+    update-notifier "^2.3.0"
+
 nomnom@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
@@ -6676,6 +6793,12 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
@@ -7006,6 +7129,15 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
+package-json@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  dependencies:
+    got "^6.7.1"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
+
 pako@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
@@ -7309,7 +7441,7 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
-ps-tree@^1.0.1:
+ps-tree@^1.0.1, ps-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
   dependencies:
@@ -7318,6 +7450,12 @@ ps-tree@^1.0.1:
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+pstree.remy@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.0.tgz#f2af27265bd3e5b32bbfcc10e80bac55ba78688b"
+  dependencies:
+    ps-tree "^1.1.0"
 
 public-encrypt@^4.0.0:
   version "4.0.2"
@@ -7451,6 +7589,15 @@ raw-body@2.3.2, raw-body@^2.3.2:
     http-errors "1.6.2"
     iconv-lite "0.4.19"
     unpipe "1.0.0"
+
+rc@^1.0.1, rc@^1.1.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.7.tgz#8a10ca30d588d00464360372b890d06dacd02297"
+  dependencies:
+    deep-extend "^0.5.1"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 rc@^1.1.7:
   version "1.2.6"
@@ -7754,6 +7901,19 @@ regexpu-core@^4.1.3:
     unicode-match-property-ecmascript "^1.0.3"
     unicode-match-property-value-ecmascript "^1.0.1"
 
+registry-auth-token@^3.0.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  dependencies:
+    rc "^1.0.1"
+
 regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
@@ -8046,7 +8206,13 @@ selfsigned@^1.9.1:
   dependencies:
     node-forge "0.7.1"
 
-"semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+semver-diff@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
+  dependencies:
+    semver "^5.0.3"
+
+"semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -8622,6 +8788,12 @@ temp@^0.8.1:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  dependencies:
+    execa "^0.7.0"
+
 text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
@@ -8711,6 +8883,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  dependencies:
+    nopt "~1.0.10"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.2.0, tough-cookie@^2.3.3, tough-cookie@~2.3.3:
   version "2.3.4"
@@ -8803,6 +8981,12 @@ uglifyjs-webpack-plugin@^1.2.4:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
+undefsafe@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.2.tgz#225f6b9e0337663e0d8e7cfd686fc2836ccace76"
+  dependencies:
+    debug "^2.2.0"
+
 underscore@~1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
@@ -8857,6 +9041,12 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  dependencies:
+    crypto-random-string "^1.0.0"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -8872,9 +9062,28 @@ untildify@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.2.tgz#7f1f302055b3fea0f3e81dc78eb36766cb65e3f1"
 
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+
 upath@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+
+update-notifier@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-ci "^1.0.10"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 uri-js@^3.0.2:
   version "3.0.2"
@@ -9246,6 +9455,12 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
+widest-line@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.0.tgz#0142a4e8a243f8882c0233aa0e0281aa76152273"
+  dependencies:
+    string-width "^2.1.1"
+
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
@@ -9279,6 +9494,14 @@ write-file-atomic@^1.2.0:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+write-file-atomic@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 write@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
@@ -9291,6 +9514,10 @@ ws@^4.0.0:
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
+
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
 "xml-name-validator@>= 2.0.1 < 3.0.0":
   version "2.0.1"


### PR DESCRIPTION
This PR seeks to merge code that introduces a new query to our GraphQL schema named 'geoLocations'. It allows one to supply a list of the IP addresses for a honey badger and then get the geospatial location (i.e. latitude/longitude) for the honey badger using that IP address.

In addition to introducing a new query to our GraphQL schema we have also updated our <App> component to issue a 'geoLocations' query and our <HoneyBadgersTable> component to make use of the new data collected.

Closes #13