### PR TITLE
feat(gql): add 'blacklists' query to GQL schema to get blacklist info

### DIFF
--- a/src/client/components/HoneyBadgerDetails.jsx
+++ b/src/client/components/HoneyBadgerDetails.jsx
@@ -7,6 +7,112 @@ import Typography from 'material-ui/Typography'
 
 import { withGoogleMap, GoogleMap, Marker } from 'react-google-maps'
 
+const renderASDetails = as => (
+  <Paper>
+    <Typography align="center" variant="title">
+      Autonomous System
+    </Typography>
+    {as ? (
+      <Grid container>
+        <Grid item xs={4}>
+          <Typography>
+            <b>Name:</b>
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          <Typography>{as.name}</Typography>
+        </Grid>
+        <Grid item xs={4}>
+          <Typography>
+            <b>ASN:</b>
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          <Typography>{as.asn}</Typography>
+        </Grid>
+        <Grid item xs={4}>
+          <Typography>
+            <b>Country Code:</b>
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          <Typography>{as.countryCode}</Typography>
+        </Grid>
+      </Grid>
+    ) : (
+      <Typography align="center">Loading...</Typography>
+    )}
+  </Paper>
+)
+
+const renderGeoLocationDetails = geoLocation => (
+  <Paper>
+    <Typography align="center" variant="title">
+      Location
+    </Typography>
+    {geoLocation ? (
+      <Grid container>
+        <Grid item xs={4}>
+          <Typography>
+            <b>Continent:</b>
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          <Typography>{geoLocation.continent}</Typography>
+        </Grid>
+        <Grid item xs={4}>
+          <Typography>
+            <b>Country:</b>
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          <Typography>{geoLocation.country}</Typography>
+        </Grid>
+      </Grid>
+    ) : (
+      <Typography align="center">Loading...</Typography>
+    )}
+  </Paper>
+)
+
+const renderBlacklistsDetails = blacklists => (
+  <Paper>
+    <Typography align="center" variant="title">
+      Blacklists
+    </Typography>
+    {blacklists ? (
+      <Grid container>
+        <Grid item xs={4}>
+          <Typography>
+            <b>Blacklisted:</b>
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          {blacklists.length > 0 ? (
+            <Typography color="error">BLACKLISTED</Typography>
+          ) : (
+            <Typography>Not blacklisted</Typography>
+          )}
+        </Grid>
+        <Grid item xs={4}>
+          <Typography>
+            <b>Blacklists:</b>
+          </Typography>
+        </Grid>
+        <Grid item xs={8}>
+          {blacklists.length > 0 ? (
+            <Typography>{blacklists.join(', ')}</Typography>
+          ) : (
+            <Typography>-</Typography>
+          )}
+        </Grid>
+      </Grid>
+    ) : (
+      <Typography align="center">Loading...</Typography>
+    )}
+  </Paper>
+)
+
 const HoneyBadgerMap = withGoogleMap(({ latitude, longitude }) => (
   <GoogleMap defaultZoom={10} defaultCenter={{ lat: latitude, lng: longitude }}>
     <Marker position={{ lat: latitude, lng: longitude }} />
@@ -14,7 +120,7 @@ const HoneyBadgerMap = withGoogleMap(({ latitude, longitude }) => (
 ))
 
 const HoneyBadgerDetails = ({ honeyBadger }) => {
-  const { geoLocation, as } = honeyBadger
+  const { geoLocation, as, blacklists } = honeyBadger
 
   return (
     <Grid container spacing={8}>
@@ -28,71 +134,14 @@ const HoneyBadgerDetails = ({ honeyBadger }) => {
           />
         </Paper>
       </Grid>
-      <Grid item xs={12} sm={6}>
-        <Paper>
-          <Typography align="center" variant="title">
-            Autonomous System
-          </Typography>
-          {as ? (
-            <Grid container>
-              <Grid item xs={4}>
-                <Typography>
-                  <b>Name:</b>
-                </Typography>
-              </Grid>
-              <Grid item xs={8}>
-                <Typography>{as.name}</Typography>
-              </Grid>
-              <Grid item xs={4}>
-                <Typography>
-                  <b>ASN:</b>
-                </Typography>
-              </Grid>
-              <Grid item xs={8}>
-                <Typography>{as.asn}</Typography>
-              </Grid>
-              <Grid item xs={4}>
-                <Typography>
-                  <b>Country Code:</b>
-                </Typography>
-              </Grid>
-              <Grid item xs={8}>
-                <Typography>{as.countryCode}</Typography>
-              </Grid>
-            </Grid>
-          ) : (
-            <Typography align="center">Loading...</Typography>
-          )}
-        </Paper>
+      <Grid item xs={12} sm={4}>
+        {renderASDetails(as)}
       </Grid>
-      <Grid item xs={12} sm={6}>
-        <Paper>
-          <Typography align="center" variant="title">
-            Location
-          </Typography>
-          {geoLocation ? (
-            <Grid container>
-              <Grid item xs={4}>
-                <Typography>
-                  <b>Continent:</b>
-                </Typography>
-              </Grid>
-              <Grid item xs={8}>
-                <Typography>{geoLocation.continent}</Typography>
-              </Grid>
-              <Grid item xs={4}>
-                <Typography>
-                  <b>Country:</b>
-                </Typography>
-              </Grid>
-              <Grid item xs={8}>
-                <Typography>{geoLocation.country}</Typography>
-              </Grid>
-            </Grid>
-          ) : (
-            <Typography align="center">Loading...</Typography>
-          )}
-        </Paper>
+      <Grid item xs={12} sm={4}>
+        {renderGeoLocationDetails(geoLocation)}
+      </Grid>
+      <Grid item xs={12} sm={4}>
+        {renderBlacklistsDetails(blacklists)}
       </Grid>
     </Grid>
   )

--- a/src/client/components/HoneyBadgersTable.jsx
+++ b/src/client/components/HoneyBadgersTable.jsx
@@ -35,24 +35,31 @@ const getHoneyBadgersRows = honeyBadgers =>
     // Supply the minimum amount of info we expect in a row which is the IP address and the amount
     // of times we have seen the entity in the last 24 hours. Add a 'Loading' flag as the default
     // for all of the other info that may not be loaded yet.
-    const { ipAddress, count, geoLocation, as } = honeyBadger
+    const { ipAddress, count, geoLocation, as, blacklists } = honeyBadger
 
     const row = {
       ipAddress,
       count,
       country: 'Loading',
       asn: 'Loading',
+      blacklisted: 'Loading',
     }
 
     // Add the additional info if it has been loaded:
     // * Autonomous system number if autonomous system info has been loaded
     // * Country of origin if geospatial location info has been loaded
+    // * Whether the honey badger has been blacklisted if the blacklists info has been loaded
     if (geoLocation) {
       row.country = geoLocation.country
     }
 
     if (as) {
       row.asn = as.asn
+    }
+
+    if (blacklists) {
+      row.blacklisted =
+        blacklists.length > 0 ? 'BLACKLISTED' : 'Not in any blacklists'
     }
 
     return row
@@ -75,8 +82,9 @@ const HoneyBadgersTable = ({ honeyBadgers }) => {
         Top honey badger activity in the last 24 hours. Click the{' '}
         <KeyboardArrowRightIcon /> to see a profile for a specific honey badger.
         You can search/filter for specific honey badgers in the top right of the
-        data table. To learn more about the Honey Badger Insights app click the
-        about tab above.
+        data table. Note that it may take a while for the data to load where you
+        will see a &#39;No Data&#39; message. To learn more about the Honey
+        Badger Insights app click the about tab above.
       </Typography>
       <Grid
         rows={getHoneyBadgersRows([...honeyBadgers.values()])}
@@ -85,6 +93,7 @@ const HoneyBadgersTable = ({ honeyBadgers }) => {
           { name: 'count', title: 'Times Seen Last 24 Hours' },
           { name: 'country', title: 'Country of Origin' },
           { name: 'asn', title: 'Autonomous System #' },
+          { name: 'blacklisted', title: 'Blacklisted' },
         ]}
       >
         <RowDetailState />

--- a/src/client/graphql/queries.js
+++ b/src/client/graphql/queries.js
@@ -31,3 +31,12 @@ export const geoLocationsQuery = gql`
     }
   }
 `
+
+export const blacklistsQuery = gql`
+  query Blacklists($ipAddresses: [String!]!) {
+    blacklists(ipAddresses: $ipAddresses) {
+      ipAddress
+      blacklists
+    }
+  }
+`

--- a/src/server/graphql/data/blacklistsData
+++ b/src/server/graphql/data/blacklistsData
@@ -1,0 +1,116 @@
+[
+  {
+    "ipAddress": "104.17.41.113",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "136.243.74.134",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "104.17.38.113",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "147.135.169.235",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "90.231.42.220",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "174.60.100.187",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "195.140.215.9",
+    "blacklists": [
+      "FAIL2BAN-SIP",
+      "UCEPROTECT-LEVEL1"
+    ]
+  },
+  {
+    "ipAddress": "81.218.45.146",
+    "blacklists": [
+      "FAIL2BAN-SSH"
+    ]
+  },
+  {
+    "ipAddress": "147.135.169.234",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "142.196.229.24",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "5.62.63.221",
+    "blacklists": [
+      "STOPFORUMSPAM-365"
+    ]
+  },
+  {
+    "ipAddress": "95.216.147.231",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "95.68.221.51",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "98.212.111.60",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "75.176.109.242",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "182.100.67.129",
+    "blacklists": [
+      "FAIL2BAN-SSH",
+      "FAIL2BAN-STRONGIPS"
+    ]
+  },
+  {
+    "ipAddress": "104.17.37.113",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "46.29.248.90",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "104.17.39.113",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "54.37.104.81",
+    "blacklists": [
+      "ALIENVAULT-REPUTATION"
+    ]
+  },
+  {
+    "ipAddress": "91.236.239.102",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "75.176.121.42",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "212.129.56.125",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "104.17.40.113",
+    "blacklists": []
+  },
+  {
+    "ipAddress": "66.70.173.21",
+    "blacklists": [
+      "ALIENVAULT-REPUTATION"
+    ]
+  }
+]

--- a/src/server/graphql/types.js
+++ b/src/server/graphql/types.js
@@ -2,6 +2,7 @@ import {
   GraphQLFloat,
   GraphQLInt,
   GraphQLNonNull,
+  GraphQLList,
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql'
@@ -57,6 +58,23 @@ export const ASType = new GraphQLObjectType({
     },
   },
   description: 'Information regarding an autonomous system',
+})
+
+export const BlacklistType = new GraphQLObjectType({
+  name: 'Blacklist',
+  fields: {
+    ipAddress: {
+      type: new GraphQLNonNull(GraphQLString),
+      description:
+        'The IP address of a honey badger that the blacklist information pertains to',
+    },
+    blacklists: {
+      type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+      description:
+        'The names of the blacklists that a honey badger belongs to, if any',
+    },
+  },
+  description: 'Blacklist information for a honey badger',
 })
 
 export const TopHoneyBadgerType = new GraphQLObjectType({

--- a/test/int/client/containers/App.spec.jsx
+++ b/test/int/client/containers/App.spec.jsx
@@ -164,4 +164,23 @@ describe('React component test: <App>', function() {
       })
     })
   })
+
+  describe('collectBlacklistsInfo():', function() {
+    it('Promise resolves to map with blacklists info injected', async function() {
+      // First query for honey badgers so we can pass them to the
+      // 'App.collectBlacklistsInfo()' method...
+      let honeyBadgers = await App.collectTopHoneyBadgersInfo()
+
+      // Now query for blacklists info and check that the map of honey badgers has been updated
+      // inline with the invocation of the 'App.collectBlacklistsInfo()' method...
+      await App.collectBlacklistsInfo(honeyBadgers)
+
+      // Check that we correctly populated our entries on our map...
+      honeyBadgers = [...honeyBadgers.values()]
+      honeyBadgers.forEach(honeyBadger => {
+        expect(honeyBadger).to.be.an('object')
+        expect(honeyBadger.blacklists).to.be.an('array')
+      })
+    })
+  })
 })

--- a/test/unit/client/components/HoneyBadgersTable.spec.jsx
+++ b/test/unit/client/components/HoneyBadgersTable.spec.jsx
@@ -81,8 +81,8 @@ describe('React component test: <HoneyBadgersTable>', function() {
 
       // This assertion is meant to remind us to update the following assertions. It will fail as
       // we add additional keys to the row data and don't update the tests. We currently expect
-      // the following keys: 'ipAddress', 'count', 'country', 'asn'
-      expect(Object.keys(row).length).to.equal(4)
+      // the following keys: 'ipAddress', 'count', 'country', 'asn', 'blacklisted'
+      expect(Object.keys(row).length).to.equal(5)
 
       // Now check for the data we expect...
       expect(row.ipAddress).to.equal(honeyBadger.ipAddress)
@@ -92,6 +92,7 @@ describe('React component test: <HoneyBadgersTable>', function() {
       // from other data we would display to say 'Loading' at this point
       expect(row.country).to.equal('Loading')
       expect(row.asn).to.equal('Loading')
+      expect(row.blacklisted).to.equal('Loading')
 
       expect(toJson(hbtWrapper)).to.matchSnapshot()
     })
@@ -124,8 +125,8 @@ describe('React component test: <HoneyBadgersTable>', function() {
 
       // This assertion is meant to remind us to update the following assertions. It will fail as
       // we add additional keys to the row data and don't update the tests. We currently expect
-      // the following keys: 'ipAddress', 'count', 'country, 'asn'
-      expect(Object.keys(row).length).to.equal(4)
+      // the following keys: 'ipAddress', 'count', 'country, 'asn', 'blacklisted'
+      expect(Object.keys(row).length).to.equal(5)
 
       // Now check for the data we expect...
       expect(row.ipAddress).to.equal(honeyBadger.ipAddress)
@@ -135,6 +136,7 @@ describe('React component test: <HoneyBadgersTable>', function() {
       // This test presumes we haven't yet queried for geospatial locations data so we expect any
       // info we would display about that data to say 'Loading' at this point
       expect(row.country).to.equal('Loading')
+      expect(row.blacklisted).to.equal('Loading')
 
       expect(toJson(hbtWrapper)).to.matchSnapshot()
     })
@@ -173,14 +175,66 @@ describe('React component test: <HoneyBadgersTable>', function() {
 
       // This assertion is meant to remind us to update the following assertions. It will fail as
       // we add additional keys to the row data and don't update the tests. We currently expect
-      // the following keys: 'ipAddress', 'count', 'country', 'asn'
-      expect(Object.keys(row).length).to.equal(4)
+      // the following keys: 'ipAddress', 'count', 'country', 'asn', 'blacklisted'
+      expect(Object.keys(row).length).to.equal(5)
 
       // Now check the data we expect...
       expect(row.ipAddress).to.equal(honeyBadger.ipAddress)
       expect(parseInt(row.count, 10)).to.equal(honeyBadger.count)
       expect(parseInt(row.asn, 10)).to.equal(honeyBadger.as.asn)
       expect(row.country).to.equal(honeyBadger.geoLocation.country)
+
+      // This test presumes we haven't yet queried for geospatial locations data so we expect any
+      // info we would display about that data to say 'Loading' at this point
+      expect(row.blacklisted).to.equal('Loading')
+
+      expect(toJson(hbtWrapper)).to.matchSnapshot()
+    })
+
+    it('Rows rendered (honey badgers data w/ AS, location, and blacklists data)', function() {
+      // Create data as if we have issued the 'topHoneyBadgers', 'autonomousSystems', and
+      // 'geoLocations' queries to our GraphQL service/API endpoint
+      const honeyBadgers = [
+        {
+          ipAddress: '1.1.1.1',
+          count: 987,
+          geoLocation: {
+            latitude: 47.6062,
+            longitude: 122.3321,
+            country: 'United State',
+            continent: 'North America',
+          },
+          as: {
+            name: 'OVH SAS',
+            asn: 16276,
+            countryCode: 'FR',
+          },
+          blacklists: ['FAIL2BNA-SIP', 'UCEPROTECT-LEVEL1'],
+        },
+      ]
+
+      hbtWrapper.setProps({ honeyBadgers })
+
+      // We should have some rows since we have some honey badgers. Check and ensure that each row
+      // specifies it is loading data where appropriate
+      const rows = hbtWrapper.find(Grid).prop('rows')
+      expect(rows.length).to.equal(honeyBadgers.length)
+
+      // Verify that we correctly set the data in a row given a honey badger
+      const honeyBadger = honeyBadgers[0]
+      const row = rows[0]
+
+      // This assertion is meant to remind us to update the following assertions. It will fail as
+      // we add additional keys to the row data and don't update the tests. We currently expect
+      // the following keys: 'ipAddress', 'count', 'country', 'asn', 'blacklisted'
+      expect(Object.keys(row).length).to.equal(5)
+
+      // Now check the data we expect...
+      expect(row.ipAddress).to.equal(honeyBadger.ipAddress)
+      expect(parseInt(row.count, 10)).to.equal(honeyBadger.count)
+      expect(parseInt(row.asn, 10)).to.equal(honeyBadger.as.asn)
+      expect(row.country).to.equal(honeyBadger.geoLocation.country)
+      expect(row.blacklisted).to.equal('BLACKLISTED')
 
       expect(toJson(hbtWrapper)).to.matchSnapshot()
     })

--- a/test/unit/client/components/HoneyBadgersTable.spec.jsx.snap
+++ b/test/unit/client/components/HoneyBadgersTable.spec.jsx.snap
@@ -8,7 +8,7 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
     Top honey badger activity in the last 24 hours. Click the
      
     <pure(KeyboardArrowRight) />
-     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. To learn more about the Honey Badger Insights app click the about tab above.
+     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. Note that it may take a while for the data to load where you will see a 'No Data' message. To learn more about the Honey Badger Insights app click the about tab above.
   </WithStyles(Typography)>
   <Grid$$1
     columns={
@@ -28,6 +28,10 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
         Object {
           "name": "asn",
           "title": "Autonomous System #",
+        },
+        Object {
+          "name": "blacklisted",
+          "title": "Blacklisted",
         },
       ]
     }
@@ -74,7 +78,7 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
     Top honey badger activity in the last 24 hours. Click the
      
     <pure(KeyboardArrowRight) />
-     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. To learn more about the Honey Badger Insights app click the about tab above.
+     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. Note that it may take a while for the data to load where you will see a 'No Data' message. To learn more about the Honey Badger Insights app click the about tab above.
   </WithStyles(Typography)>
   <Grid$$1
     columns={
@@ -95,12 +99,97 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
           "name": "asn",
           "title": "Autonomous System #",
         },
+        Object {
+          "name": "blacklisted",
+          "title": "Blacklisted",
+        },
       ]
     }
     rows={
       Array [
         Object {
           "asn": 16276,
+          "blacklisted": "Loading",
+          "count": 987,
+          "country": "United State",
+          "ipAddress": "1.1.1.1",
+        },
+      ]
+    }
+  >
+    <RowDetailState
+      defaultExpandedRowIds={Array []}
+    />
+    <SearchState
+      defaultValue=""
+    />
+    <IntegratedFiltering />
+    <PagingState
+      defaultCurrentPage={0}
+      defaultPageSize={10}
+      pageSize={5}
+    />
+    <IntegratedPaging />
+    <Table$$1
+      messages={Object {}}
+    />
+    <TableHeaderRow$$1
+      messages={Object {}}
+    />
+    <TableRowDetail$$1
+      contentComponent={[Function]}
+    />
+    <Toolbar$$1 />
+    <SearchPanel$$1
+      messages={Object {}}
+    />
+    <PagingPanel$$1
+      messages={Object {}}
+    />
+  </Grid$$1>
+</div>
+`;
+
+exports[`React component test: <HoneyBadgersTable> Renders correctly for given application state: Rows rendered (honey badgers data w/ AS, location, and blacklists data) 1`] = `
+<div>
+  <WithStyles(Typography)
+    paragraph={true}
+  >
+    Top honey badger activity in the last 24 hours. Click the
+     
+    <pure(KeyboardArrowRight) />
+     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. Note that it may take a while for the data to load where you will see a 'No Data' message. To learn more about the Honey Badger Insights app click the about tab above.
+  </WithStyles(Typography)>
+  <Grid$$1
+    columns={
+      Array [
+        Object {
+          "name": "ipAddress",
+          "title": "IP Address",
+        },
+        Object {
+          "name": "count",
+          "title": "Times Seen Last 24 Hours",
+        },
+        Object {
+          "name": "country",
+          "title": "Country of Origin",
+        },
+        Object {
+          "name": "asn",
+          "title": "Autonomous System #",
+        },
+        Object {
+          "name": "blacklisted",
+          "title": "Blacklisted",
+        },
+      ]
+    }
+    rows={
+      Array [
+        Object {
+          "asn": 16276,
+          "blacklisted": "BLACKLISTED",
           "count": 987,
           "country": "United State",
           "ipAddress": "1.1.1.1",
@@ -149,7 +238,7 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
     Top honey badger activity in the last 24 hours. Click the
      
     <pure(KeyboardArrowRight) />
-     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. To learn more about the Honey Badger Insights app click the about tab above.
+     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. Note that it may take a while for the data to load where you will see a 'No Data' message. To learn more about the Honey Badger Insights app click the about tab above.
   </WithStyles(Typography)>
   <Grid$$1
     columns={
@@ -170,12 +259,17 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
           "name": "asn",
           "title": "Autonomous System #",
         },
+        Object {
+          "name": "blacklisted",
+          "title": "Blacklisted",
+        },
       ]
     }
     rows={
       Array [
         Object {
           "asn": 16276,
+          "blacklisted": "Loading",
           "count": 987,
           "country": "Loading",
           "ipAddress": "1.1.1.1",
@@ -224,7 +318,7 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
     Top honey badger activity in the last 24 hours. Click the
      
     <pure(KeyboardArrowRight) />
-     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. To learn more about the Honey Badger Insights app click the about tab above.
+     to see a profile for a specific honey badger. You can search/filter for specific honey badgers in the top right of the data table. Note that it may take a while for the data to load where you will see a 'No Data' message. To learn more about the Honey Badger Insights app click the about tab above.
   </WithStyles(Typography)>
   <Grid$$1
     columns={
@@ -245,12 +339,17 @@ exports[`React component test: <HoneyBadgersTable> Renders correctly for given a
           "name": "asn",
           "title": "Autonomous System #",
         },
+        Object {
+          "name": "blacklisted",
+          "title": "Blacklisted",
+        },
       ]
     }
     rows={
       Array [
         Object {
           "asn": "Loading",
+          "blacklisted": "Loading",
           "count": 987,
           "country": "Loading",
           "ipAddress": "1.1.1.1",


### PR DESCRIPTION
This PR seeks to merge a new query to our GraphQL schema named 'blacklists'. It allows on to supply a list of IP addresses for a honey badger and then get info regarding whether a honey badger has been
blacklisted or not.

In addition to introducing a new query to our GraphQL schema we have also updated our <App> component to issue a 'blacklists' query and our <HoneyBadgersTable> component to make use of the new data collected.

Closes #17