### PR TITLE
docs: remove Google API key for Google Maps JavaScript library

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCRzyadawvDVWF-Bv0p6d-DrfUaYdvcwkw"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=YOUR_GOOGLE_API_KEY"></script>
   </head>
   <body>
     <div id="root">


### PR DESCRIPTION
Commit a10412faf30ce6a9af370e5ae8b30df3b77c6ded added an API key for the Google Maps JavaScript library as a way to allow a select audience to get the project going right away by simply cloning this project. I am now removing it as it is no longer neeeded. The key has also been
deleted and won't work any longer.

Closes #20